### PR TITLE
Disable Global Scopes by default

### DIFF
--- a/src/Engines/MySQLEngine.php
+++ b/src/Engines/MySQLEngine.php
@@ -55,7 +55,9 @@ class MySQLEngine extends Engine
         $params = $mode->buildParams($builder);
 
         $model = $builder->model;
-        $query = $model::whereRaw($whereRawString, $params)->withoutGlobalScopes();
+        // VME retail custom code: add filters
+        $filters = call_user_func($builder->callback);
+        $query = $model::whereRaw($whereRawString, $params)->filter($filters)->withoutGlobalScopes();
 
         $result['count'] = $query->count();
 


### PR DESCRIPTION
In most cases, we don't want global scopes to be used. I think this should be the default desired behaviour.