### PR TITLE
Wraps index fields with backticks

### DIFF
--- a/src/Services/IndexService.php
+++ b/src/Services/IndexService.php
@@ -64,7 +64,9 @@ class IndexService
     {
         $indexName = $this->modelService->indexName;
         $tableName = $this->modelService->tableName;
-        $indexFields = implode(',', $this->modelService->getFullTextIndexFields());
+        $indexFields = implode(',', array_map(function($indexField) {
+            return "`$indexField`";
+        }, $this->modelService->getFullTextIndexFields()));
 
         if (empty($indexFields)) {
             return;


### PR DESCRIPTION
This prevents query errors with column names like `key`.