### PR TITLE
Use ordered query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ would produce the following query in `NATURAL_LANGUAGE` mode:
 
 
 ```sql
-select * from `posts` where MATCH(content,meta) AGAINST(:_search IN NATURAL LANGUAGE MODE)
+select * from `posts` where MATCH(content,meta) AGAINST(? IN NATURAL LANGUAGE MODE)
 ```
 
 and the following query in `BOOLEAN` mode:
 
 ```sql
-select * from `posts` where MATCH(content,meta) AGAINST(:_search IN BOOLEAN MODE)
+select * from `posts` where MATCH(content,meta) AGAINST(? IN BOOLEAN MODE)
 ```
 
 Operators for `BOOLEAN` mode should be passed as part of the search string.
@@ -143,7 +143,7 @@ For more information see the
 
 ### LIKE and LIKE_EXPANDED Modes
 
-`LIKE` and `LIKE_EXPANDED` modes will run `WHERE LIKE %:_search%` queries that will include all of the Model's fields 
+`LIKE` and `LIKE_EXPANDED` modes will run `WHERE LIKE %?%` queries that will include all of the Model's fields 
 returned from `toSearchableArray()`. `LIKE_EXPANDED` mode will query each field using each individual word in the search string.
 
 For example running a search on a `Customer` model with the following database structure:

--- a/src/Engines/Modes/Boolean.php
+++ b/src/Engines/Modes/Boolean.php
@@ -15,14 +15,14 @@ class Boolean extends Mode
 
         $indexFields = implode(',',  $this->modelService->setModel($builder->model)->getFullTextIndexFields());
 
-        $queryString .= "MATCH($indexFields) AGAINST(:_search IN BOOLEAN MODE)";
+        $queryString .= "MATCH($indexFields) AGAINST(? IN BOOLEAN MODE)";
 
         return $queryString;
     }
 
     public function buildParams(Builder $builder)
     {
-        $this->whereParams['_search'] = $builder->query;
+        $this->whereParams[] = $builder->query;
 
         return $this->whereParams;
     }

--- a/src/Engines/Modes/Like.php
+++ b/src/Engines/Modes/Like.php
@@ -19,10 +19,8 @@ class Like extends Mode
 
         $queryString .= '(';
 
-        $itr = 0;
         foreach ($this->fields as $field) {
-            $queryString .= "`$field` LIKE :_search$itr OR ";
-            ++$itr;
+            $queryString .= "`$field` LIKE ? OR ";
         }
 
         $queryString = trim($queryString, 'OR ');
@@ -34,7 +32,7 @@ class Like extends Mode
     public function buildParams(Builder $builder)
     {
         for ($itr = 0; $itr < count($this->fields); ++$itr) {
-            $this->whereParams["_search$itr"] = '%'.$builder->query.'%';
+            $this->whereParams[] = '%'.$builder->query.'%';
         }
 
         return $this->whereParams;

--- a/src/Engines/Modes/LikeExpanded.php
+++ b/src/Engines/Modes/LikeExpanded.php
@@ -21,12 +21,9 @@ class LikeExpanded extends Mode
 
         $queryString .= '(';
 
-        $itr = 0;
-
         foreach ($this->fields as $field) {
             foreach ($words as $word) {
-                $queryString .= "`$field` LIKE :_search$itr OR ";
-                ++$itr;
+                $queryString .= "`$field` LIKE ? OR ";
             }
         }
 
@@ -40,11 +37,9 @@ class LikeExpanded extends Mode
     {
         $words = explode(' ', $builder->query);
 
-        $itr = 0;
         for ($i = 0; $i < count($this->fields); ++$i) {
             foreach ($words as $word) {
-                $this->whereParams["_search$itr"] = '%'.$word.'%';
-                ++$itr;
+                $this->whereParams[] = '%'.$word.'%';
             }
         }
 

--- a/src/Engines/Modes/Mode.php
+++ b/src/Engines/Modes/Mode.php
@@ -37,7 +37,7 @@ abstract class Mode
 
             $this->whereParams[$field] = $value;
 
-            $queryString .= "$field $operator :$field AND ";
+            $queryString .= "$field $operator ? AND ";
         }
 
         return $queryString;

--- a/src/Engines/Modes/NaturalLanguage.php
+++ b/src/Engines/Modes/NaturalLanguage.php
@@ -14,7 +14,7 @@ class NaturalLanguage extends Mode
 
         $indexFields = implode(',',  $this->modelService->setModel($builder->model)->getFullTextIndexFields());
 
-        $queryString .= "MATCH($indexFields) AGAINST(:_search IN NATURAL LANGUAGE MODE";
+        $queryString .= "MATCH($indexFields) AGAINST(? IN NATURAL LANGUAGE MODE";
 
         if (config('scout.mysql.query_expansion')) {
             $queryString .= ' WITH QUERY EXPANSION';
@@ -27,7 +27,7 @@ class NaturalLanguage extends Mode
 
     public function buildParams(Builder $builder)
     {
-        $this->whereParams['_search'] = $builder->query;
+        $this->whereParams[] = $builder->query;
 
         return $this->whereParams;
     }


### PR DESCRIPTION
Use ordered parameters instead of named to solve issues with Eloquent global scopes.