### PR TITLE
Don't try to index classes that don't use Searchable

### DIFF
--- a/src/Services/IndexService.php
+++ b/src/Services/IndexService.php
@@ -31,6 +31,10 @@ class IndexService
             foreach ($files as $file) {
                 $class = getClassFullNameFromFile($file);
 
+                if (! class_exists($class) || ! in_array(Searchable::class, class_uses($class))) {
+                    continue;
+                }
+
                 $modelInstance = new $class();
 
                 $connectionName = $modelInstance->getConnectionName() !== null ?
@@ -38,7 +42,7 @@ class IndexService
 
                 $isMySQL = config("database.connections.$connectionName.driver") === 'mysql';
 
-                if (class_exists($class) && in_array(Searchable::class, class_uses($class)) && $isMySQL) {
+                if ($isMySQL) {
                     $searchableModels[] = $class;
                 }
             }


### PR DESCRIPTION
The check for the Searchable trait is too far into the loop. 
This causes problems if the directory being searched contains classes that are not Eloquent models. 