### PR TITLE
Added IN statement for WHERE condition and Added whereIn macro to Laravel\Scout\Builder Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,21 @@ Simple constraints can be applied using the `where()` builder method
 
 `$beers = App\Drink::search('beer')->where('in_stock', 1)->get();`
 
-The following operators can be applied to the `WHERE` statements: `<> != = <= < >= >`
+The following operators can be applied to the `WHERE` statements: `<> != = <= < >= > IN`
 (`=` will be used if no operator is specified)
 
 `$beers = App\Drink::search('beer')->where('abv >', 10)->get();`
+
+`$beers = App\Drink::search('beer')->where('abv IN', '(8,9,10)')->get();`
+
+Thanks to IN statement it's possible to apply complex constraints. Get a Collection and call the `pluck` method, then pass the result to `whereIn` Scout Builder method:
+
+```php
+
+    $matching = App\Drink::whereHas('ownglasses')->pluck('id');
+	$beers = App\Drink::search('beer')->whereIn('id',$matching)->get();
+
+```
 
 For more usage information see the [Laravel Scout Documentation](https://laravel.com/docs/5.3/scout).
 

--- a/src/Engines/Modes/Mode.php
+++ b/src/Engines/Modes/Mode.php
@@ -36,8 +36,18 @@ abstract class Mode
             $value = $parsedWhere[2];
 
             if ($value !== null) {
-                $this->whereParams[$field] = $value;
-                $queryString .= "$field $operator ? AND ";
+                if($operator == 'IN')
+                {
+                    if($value == '()')
+                        $queryString .= "0=1 AND ";
+                    else
+                        $queryString .= "$field $operator $value AND ";
+                }
+                else
+                {
+                    $this->whereParams[$field] = $value;
+                    $queryString .= "$field $operator ? AND ";
+                }
             } else {
                 $queryString .= "$field IS NULL AND ";
             }
@@ -48,7 +58,7 @@ abstract class Mode
 
     private function parseWheres($wheres)
     {
-        $pattern = '/([A-Za-z_]+[A-Za-z_0-9]?)[ ]?(<>|!=|=|<=|<|>=|>)/';
+        $pattern = '/([A-Za-z_]+[A-Za-z_0-9]?)[ ]?(<>|!=|=|<=|<|>=|>|IN)/';
 
         $result = array();
         foreach ($wheres as $field => $value) {

--- a/src/Providers/MySQLScoutServiceProvider.php
+++ b/src/Providers/MySQLScoutServiceProvider.php
@@ -11,6 +11,8 @@ use Yab\MySQLScout\Services\ModelService;
 use Yab\MySQLScout\Services\IndexService;
 use Yab\MySQLScout\Commands\ManageIndexes;
 
+use Laravel\Scout\Builder;
+
 class MySQLScoutServiceProvider extends ServiceProvider
 {
     /**
@@ -26,6 +28,12 @@ class MySQLScoutServiceProvider extends ServiceProvider
 
         $this->app->make(EngineManager::class)->extend('mysql', function () {
             return new MySQLEngine(app(ModeContainer::class));
+        });
+		
+		// Add Macro WhereIn
+		Builder::macro('whereIn', function ($field,$collection) {
+            $this->where($field.' IN ','('.(implode(',',$collection->toArray())).')');
+            return $this;
         });
     }
 


### PR DESCRIPTION
Hi there,
today I used your package for the first time, thanks a lot.
I needed a way to perform complex query and a fulltext search, so I added a whereIn macro to Laravel\Scout\Builder and I added the support for IN statement to your Yab\MySQLScout\Engines\Modes\Mode object . So now it's possible to perform a complex query, get all the IDS resulting, and pass them to the Laravel\Scout\Builder::whereIn new method.
I hope you'll like this and accept this pull request.
