### PR TITLE
Add support for case-insensitve LIKE and LIKE_EXPANDED search

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,31 @@ and the following query in `LIKE_EXPANDED` mode given the search string "John Sm
 SELECT * FROM `customers` WHERE (`id` LIKE '%John%' OR `id` LIKE '%Smith%' OR `first_name` LIKE '%John%' OR `first_name` LIKE '%Smith%' OR `last_name` LIKE '%John%' OR `last_name` LIKE '%Smith%')
 ```
 
+### LIKE_CASE_INSENSITIVE and LIKE_EXPANDED_CASE_INSENSITIVE Modes
+
+`LIKE_CASE_INSENSITIVE` and `LIKE_EXPANDED_CASE_INSENSITIVE` modes are similar to `LIKE` and `LIKE_EXPANDED` modes except they will force both the field and parameter to lowercase in order 
+to perform a case-insensitive search. Note that you do not need to use this if you are already using a case-insensitive collation.
+
+For example running a search on a `Customer` model with the following database structure:
+
+| column name | type             |
+|-------------|------------------|
+| id          | int(10) UN AI PK |
+| first_name  | VARCHAR(255)     |
+| last_name   | VARCHAR(255)     |
+
+would produce the following query in `LIKE_CASE_INSENSITIVE` mode given the search string "John":
+
+```sql
+SELECT * FROM `customers` WHERE (LCASE(`id`) LIKE LOWER('%John%') OR LCASE(`first_name`) LIKE LOWER('%John%') OR LCASE(`last_name`) LIKE LOWER('%JOHN%'))
+```
+
+and the following query in `LIKE_EXPANDED_CASE_INSENSITIVE` mode given the search string "John Smith":
+
+```sql
+SELECT * FROM `customers` WHERE (LCASE(`id`) LIKE LOWER('%John%') OR LCASE(`id`) LIKE LOWER('%Smith%') OR LCASE(`first_name`) LIKE LOWER('%John%') OR LCASE(`first_name`) LIKE LOWER('%Smith%') OR LCASE(`last_name`) LIKE LOWER('%John%') OR LCASE(`last_name`) LIKE LOWER('%Smith%'))
+```
+
 Console Command <div id="console-command"></div>
 ---------------
 

--- a/src/Engines/Modes/LikeCaseInsensitive.php
+++ b/src/Engines/Modes/LikeCaseInsensitive.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Yab\MySQLScout\Engines\Modes;
+
+use Laravel\Scout\Builder;
+use Yab\MySQLScout\Services\ModelService;
+
+class LikeCaseInsensitive extends Mode
+{
+    protected $fields;
+
+    public function buildWhereRawString(Builder $builder)
+    {
+        $queryString = '';
+
+        $this->fields = $this->modelService->setModel($builder->model)->getSearchableFields();
+
+        $queryString .= $this->buildWheres($builder);
+
+        $queryString .= '(';
+
+        foreach ($this->fields as $field) {
+            $queryString .= "LCASE(`$field`) LIKE LOWER(?) OR ";
+        }
+
+        $queryString = trim($queryString, 'OR ');
+        $queryString .= ')';
+
+        return $queryString;
+    }
+
+    public function buildParams(Builder $builder)
+    {
+        for ($itr = 0; $itr < count($this->fields); ++$itr) {
+            $this->whereParams[] = '%'.$builder->query.'%';
+        }
+
+        return $this->whereParams;
+    }
+
+    public function isFullText()
+    {
+        return false;
+    }
+}

--- a/src/Engines/Modes/LikeExpandedCaseInsensitive.php
+++ b/src/Engines/Modes/LikeExpandedCaseInsensitive.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Yab\MySQLScout\Engines\Modes;
+
+use Laravel\Scout\Builder;
+use Yab\MySQLScout\Services\ModelService;
+
+class LikeExpandedCaseInsensitive extends Mode
+{
+    protected $fields;
+
+    public function buildWhereRawString(Builder $builder)
+    {
+        $queryString = '';
+
+        $this->fields = $this->modelService->setModel($builder->model)->getSearchableFields();
+
+        $queryString .= $this->buildWheres($builder);
+
+        $words = explode(' ', $builder->query);
+
+        $queryString .= '(';
+
+        foreach ($this->fields as $field) {
+            foreach ($words as $word) {
+                $queryString .= "LCASE(`$field`) LIKE LOWER(?) OR ";
+            }
+        }
+
+        $queryString = trim($queryString, 'OR ');
+        $queryString .= ')';
+
+        return $queryString;
+    }
+
+    public function buildParams(Builder $builder)
+    {
+        $words = explode(' ', $builder->query);
+
+        for ($i = 0; $i < count($this->fields); ++$i) {
+            foreach ($words as $word) {
+                $this->whereParams[] = '%'.$word.'%';
+            }
+        }
+
+        return $this->whereParams;
+    }
+
+    public function isFullText()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
I needed the ability to always perform a case-insensitive LIKE search using this package. This seemed the simplest way to implement it and it works for me. It could be dried up to inherit from the existing LIKE and LIKE_EXPANDED classes, but it looks to me like your mode classes might be deliberately standalone and so I also follow that convention here.