### PR TITLE
Fix where() not working

### DIFF
--- a/src/Engines/MySQLEngine.php
+++ b/src/Engines/MySQLEngine.php
@@ -65,7 +65,6 @@ class MySQLEngine extends Engine
 
         $whereRawString = $mode->buildWhereRawString($builder);
         $params = $mode->buildParams($builder);
-        ksort($params,SORT_NATURAL);
 
         $model = $builder->model;
         $query = $model::whereRaw($whereRawString, $params);


### PR DESCRIPTION
Hi, I was trying to use `->where()` after `->search()` with no success. The problem was the order of the parameters in the query. 
I realized that commenting a line in `src/Engines/MySQLEngine.php` fixes it.

Example with query `Inventory::search('papa')->where('category_id', 97)->get()`:
Before change:
   ```
 "query" => "select *, MATCH(name,tags) AGAINST(? IN NATURAL LANGUAGE MODE) as relevance from `inventories` where category_id = ? AND MATCH(name,tags) AGAINST(? IN NATURAL LANGUAGE MODE) and `inventories`.`deleted_at` is null"
    "bindings" => array:3 [
      0 => "papa"
      1 => "papa"
      2 => 97
    ]
```

After change, bindings are in correct order:

```
    "query" => "select *, MATCH(name,tags) AGAINST(? IN NATURAL LANGUAGE MODE) as relevance from `inventories` where category_id = ? AND MATCH(name,tags) AGAINST(? IN NATURAL LANGUAGE MODE) and `inventories`.`deleted_at` is null"
    "bindings" => array:3 [
      0 => "papa"
      1 => 97
      2 => "papa"
    ]
```